### PR TITLE
debian: use PYTHONUNBEFFERED instead of python -u

### DIFF
--- a/debian/wazo-plugind.service
+++ b/debian/wazo-plugind.service
@@ -4,8 +4,9 @@ After=network.target consul.target
 Before=monit.service
 
 [Service]
+Environment=PYTHONUNBUFFERED=TRUE
 ExecStartPre=/usr/bin/install -d -o wazo-plugind -g wazo-plugind /run/wazo-plugind
-ExecStart=/usr/bin/python3 -u /usr/bin/wazo-plugind
+ExecStart=/usr/bin/wazo-plugind
 PIDFile=/run/wazo-plugind/wazo-plugind.pid
 
 [Install]


### PR DESCRIPTION
reason: to see the daemon name in the journalctl/syslog instead of
`python3`