### PR TITLE
use auth without ssl by default

### DIFF
--- a/etc/wazo-plugind/config.yml
+++ b/etc/wazo-plugind/config.yml
@@ -56,4 +56,5 @@ service_discovery:
 auth:
   host: localhost
   port: 9497
-  verify_certificate: /usr/share/xivo-certs/server.crt
+  prefix: null
+  https: false

--- a/integration_tests/assets/etc/wazo-plugind/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-plugind/conf.d/50-default.yml
@@ -2,7 +2,6 @@ debug: true
 
 auth:
   host: auth
-  verify_certificate: false
   key_file: /etc/wazo-plugind/key.yml
 
 bus:

--- a/wazo_plugind/config.py
+++ b/wazo_plugind/config.py
@@ -81,7 +81,8 @@ _DEFAULT_CONFIG = dict(
     auth={
         'host': 'localhost',
         'port': 9497,
-        'verify_certificate': _DEFAULT_CERT_FILE,
+        'prefix': None,
+        'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-plugind-key.yml',
     },
 )


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-test-helpers/pull/31

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1689