### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -40,7 +40,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
         os.path.join(os.path.dirname(__file__), '../..', 'assets')
     )
     service = 'plugind'
-    bus_config = dict(user='guest', password='guest', host='localhost')
+    bus_config = dict(user='guest', password='guest', host='127.0.0.1')
 
     def setUp(self):
         self.msg_accumulator = self.new_message_accumulator('plugin.#')
@@ -62,7 +62,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
         }
         if version:
             client_args['version'] = version
-        return Client('localhost', **client_args)
+        return Client('127.0.0.1', **client_args)
 
     def get_market(self, namespace, name, **kwargs):
         client = self.get_client(**kwargs)

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -19,6 +19,6 @@ class TestDocumentation(BaseIntegrationTest):
 
     def test_documentation_errors(self):
         port = self.service_port(9503, 'plugind')
-        api_url = 'http://localhost:{port}/0.2/api/api.yml'.format(port=port)
+        api_url = 'http://127.0.0.1:{port}/0.2/api/api.yml'.format(port=port)
         api = requests.get(api_url)
         validate_v2_spec(yaml.safe_load(api.text))


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6