### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,7 +1,6 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-plugind-client/archive/master.zip
-docker-compose
 kombu
 mock
 openapi-spec-validator


### PR DESCRIPTION
why: to have the latest docker-compose