### PR TITLE
Wazo-2638: Migrate wazo-plugind from Marshmallow 3.0.0b14 to 3.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flask==1.0.2
 flask-cors==3.0.7
 flask-restful==0.3.7
 kombu==4.6.11
-marshmallow==3.0.0b14
+marshmallow==3.10.0
 python-consul==0.7.1
 pyyaml==3.13
 netifaces==0.10.4

--- a/wazo_plugind/download.py
+++ b/wazo_plugind/download.py
@@ -3,7 +3,7 @@
 
 import os
 import logging
-from marshmallow import ValidationError
+from marshmallow import ValidationError, EXCLUDE
 from . import db
 from .exceptions import (
     InvalidInstallParamException,
@@ -57,7 +57,7 @@ class _MarketDownloader:
                 version_info[key] = value
 
         try:
-            body = PluginInstallSchema().load(version_info)
+            body = PluginInstallSchema().load(version_info, unknown=EXCLUDE)
         except ValidationError as e:
             raise InvalidInstallParamException(e.messages)
 

--- a/wazo_plugind/helpers/validator.py
+++ b/wazo_plugind/helpers/validator.py
@@ -4,7 +4,7 @@
 import logging
 import re
 
-from marshmallow import ValidationError
+from marshmallow import ValidationError, EXCLUDE
 from wazo_plugind.db import PluginDB
 from wazo_plugind.schema import PluginMetadataSchema as _PluginMetadataSchema
 from wazo_plugind.exceptions import (
@@ -38,7 +38,7 @@ class Validator:
         )
 
         try:
-            body = self._PluginMetadataSchema().load(metadata)
+            body = self._PluginMetadataSchema().load(metadata, unknown=EXCLUDE)
         except ValidationError as e:
             raise PluginValidationException(e.messages)
         logger.debug('validated metadata: %s', body)

--- a/wazo_plugind/http.py
+++ b/wazo_plugind/http.py
@@ -8,7 +8,7 @@ import yaml
 from flask import Flask, make_response, request
 from flask_cors import CORS
 from flask_restful import Api, Resource
-from marshmallow import ValidationError
+from marshmallow import ValidationError, EXCLUDE
 from pkg_resources import resource_string
 from xivo import http_helpers
 from xivo.http_helpers import add_logger, reverse_proxy_fix_api_spec
@@ -106,7 +106,7 @@ class Market(_AuthentificatedResource):
     @required_acl('plugind.market.read')
     def get(self):
         try:
-            list_params = MarketListRequestSchema().load(request.args)
+            list_params = MarketListRequestSchema().load(request.args, unknown=EXCLUDE)
         except ValidationError as e:
             raise InvalidListParamException(e.messages)
 
@@ -122,7 +122,7 @@ class Market(_AuthentificatedResource):
             )
         except requests.exceptions.ConnectionError:
             raise MarketNotFoundException
-        items = MarketListResultSchema().load(plugin_list, many=True)
+        items = MarketListResultSchema().load(plugin_list, many=True, unknown=EXCLUDE)
         return {
             'items': items,
             'total': self.plugin_service.count_from_market(market_proxy, **list_params),
@@ -169,12 +169,14 @@ class Plugins(_AuthentificatedResource):
     @required_acl('plugind.plugins.create')
     def post(self):
         try:
-            body = PluginInstallSchema().load(request.get_json())
+            body = PluginInstallSchema().load(request.get_json(), unknown=EXCLUDE)
         except ValidationError as e:
             raise InvalidInstallParamException(e.messages)
 
         try:
-            params = PluginInstallQueryStringSchema().load(request.args)
+            params = PluginInstallQueryStringSchema().load(
+                request.args, unknown=EXCLUDE
+            )
         except ValidationError as e:
             raise InvalidInstallQueryStringException(e.messages)
 

--- a/wazo_plugind/schema.py
+++ b/wazo_plugind/schema.py
@@ -69,7 +69,7 @@ class PluginMetadataSchema(Schema):
     depends = fields.Nested(MarketInstallOptionsSchema, many=True, unknown=EXCLUDE)
 
     @pre_load
-    def ensure_string_versions(self, data):
+    def ensure_string_versions(self, data, **kwargs):
         for field in self.version_fields:
             if field not in data:
                 continue
@@ -119,7 +119,7 @@ class OptionField(fields.Field):
         'market': fields.Nested(MarketInstallOptionsSchema, unknown=EXCLUDE),
     }
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         method = data.get('method')
         concrete_options = self._options.get(method)
         if not concrete_options:
@@ -130,7 +130,7 @@ class OptionField(fields.Field):
 class PluginInstallSchema(Schema):
 
     method = fields.String(validate=OneOf(['git', 'market']), required=True)
-    options = OptionField(missing=dict, required=True)
+    options = OptionField(missing=dict, required=False)
 
 
 class PluginInstallQueryStringSchema(Schema):

--- a/wazo_plugind/tasks.py
+++ b/wazo_plugind/tasks.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import yaml
 from threading import Thread
-from marshmallow import ValidationError
+from marshmallow import ValidationError, EXCLUDE
 from .context import Context
 from . import bus, debian, download, schema
 from .exceptions import (
@@ -232,7 +232,7 @@ class _PackageBuilder:
 
     def install_dependency(self, ctx, dep, current_wazo_version):
         try:
-            schema.DependencyMetadataSchema().load(dep)
+            schema.DependencyMetadataSchema().load(dep, unknown=EXCLUDE)
         except ValidationError:
             ctx.log(logger.info, 'invalid dependency %s skipping', dep)
             return

--- a/wazo_plugind/tests/test_schema.py
+++ b/wazo_plugind/tests/test_schema.py
@@ -3,7 +3,7 @@
 
 from unittest import TestCase
 
-from marshmallow import ValidationError
+from marshmallow import ValidationError, EXCLUDE
 from hamcrest import (
     all_of,
     assert_that,
@@ -34,7 +34,7 @@ class TestMarketResultSchema(TestCase):
             ],
         }
 
-        result = MarketListResultSchema().load(plugin_info)
+        result = MarketListResultSchema().load(plugin_info, unknown=EXCLUDE)
 
         assert_that(
             result,
@@ -43,17 +43,10 @@ class TestMarketResultSchema(TestCase):
 
 
 class TestInstallationSchema(TestCase):
-    def test_git_options_required(self):
-        input_ = {'method': 'git'}
-        assert_that(
-            calling(PluginInstallSchema().load).with_args(input_),
-            raises(ValidationError, has_property('messages', has_key('options'))),
-        )
-
     def test_git_options_url_required(self):
         input_ = {'method': 'git', 'options': {}}
         assert_that(
-            calling(PluginInstallSchema().load).with_args(input_),
+            calling(PluginInstallSchema().load).with_args(input_, unknown=EXCLUDE),
             raises(
                 ValidationError,
                 has_property('messages', has_entry('options', has_key('url'))),
@@ -62,20 +55,13 @@ class TestInstallationSchema(TestCase):
 
     def test_git_options_ref_default(self):
         input_ = {'method': 'git', 'options': {'url': 'file://my-git-repo.git'}}
-        result = PluginInstallSchema().load(input_)
+        result = PluginInstallSchema().load(input_, unknown=EXCLUDE)
         assert_that(result, has_entries(options=has_entries(ref='master')))
-
-    def test_market_options_required(self):
-        input_ = {'method': 'market'}
-        assert_that(
-            calling(PluginInstallSchema().load).with_args(input_),
-            raises(ValidationError, has_property('messages', has_key('options'))),
-        )
 
     def test_market_options_namespace_name_required(self):
         input_ = {'method': 'market', 'options': {}}
         assert_that(
-            calling(PluginInstallSchema().load).with_args(input_),
+            calling(PluginInstallSchema().load).with_args(input_, unknown=EXCLUDE),
             raises(
                 ValidationError,
                 has_property(
@@ -88,6 +74,6 @@ class TestInstallationSchema(TestCase):
     def test_none(self):
         input_ = None
         assert_that(
-            calling(PluginInstallSchema().load).with_args(input_),
+            calling(PluginInstallSchema().load).with_args(input_, unknown=EXCLUDE),
             raises(ValidationError, has_property('messages', has_key('method'))),
         )


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/93