### PR TITLE
test: use mock from unittest library

### DIFF
--- a/integration_tests/suite/test_plugin_installation.py
+++ b/integration_tests/suite/test_plugin_installation.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -13,7 +13,7 @@ from hamcrest import (
     is_,
 )
 from requests import HTTPError
-from mock import ANY
+from unittest.mock import ANY
 from wazo_test_helpers import until
 from wazo_test_helpers.hamcrest.raises import raises
 from wazo_test_helpers.hamcrest.uuid_ import uuid_

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -2,7 +2,6 @@ https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-plugind-client/archive/master.zip
 kombu
-mock
 openapi-spec-validator
 pyhamcrest
 pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
-mock
 pyhamcrest
 pytest

--- a/wazo_plugind/helpers/tests/test_validator.py
+++ b/wazo_plugind/helpers/tests/test_validator.py
@@ -1,9 +1,9 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
 from hamcrest import assert_that, calling, has_properties, not_
-from mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock, patch
 from wazo_test_helpers.hamcrest.raises import raises
 
 from wazo_plugind import exceptions

--- a/wazo_plugind/tests/test_bus.py
+++ b/wazo_plugind/tests/test_bus.py
@@ -1,8 +1,8 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
-from mock import Mock, sentinel as s
+from unittest.mock import Mock, sentinel as s
 from xivo_bus.resources.plugins.events import (
     PluginInstallProgressEvent,
     PluginUninstallProgressEvent,

--- a/wazo_plugind/tests/test_context.py
+++ b/wazo_plugind/tests/test_context.py
@@ -1,9 +1,9 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
 from hamcrest import assert_that, equal_to
-from mock import Mock, sentinel as s
+from unittest.mock import Mock, sentinel as s
 from wazo_test_helpers.hamcrest.uuid_ import uuid_
 
 from ..context import Context

--- a/wazo_plugind/tests/test_db.py
+++ b/wazo_plugind/tests/test_db.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -12,7 +12,7 @@ from hamcrest import (
     has_entries,
     raises,
 )
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from ..config import _DEFAULT_CONFIG
 from ..db import (

--- a/wazo_plugind/tests/test_debian.py
+++ b/wazo_plugind/tests/test_debian.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -8,7 +8,7 @@ from unittest import TestCase
 from string import ascii_lowercase
 from operator import itemgetter
 from hamcrest import assert_that, contains_inanyorder, equal_to
-from mock import sentinel as s
+from unittest.mock import sentinel as s
 from jinja2 import DictLoader, Environment
 from ..context import Context
 from ..debian import Generator, PackageDB

--- a/wazo_plugind/tests/test_download.py
+++ b/wazo_plugind/tests/test_download.py
@@ -1,8 +1,8 @@
-# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 
 from wazo_plugind import context, download

--- a/wazo_plugind/tests/test_http.py
+++ b/wazo_plugind/tests/test_http.py
@@ -1,11 +1,11 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
 
 from functools import wraps
 from hamcrest import assert_that, equal_to, has_entries
-from mock import ANY, Mock, patch, sentinel
+from unittest.mock import ANY, Mock, patch, sentinel
 from unittest import TestCase
 
 from ..exceptions import PluginNotFoundException

--- a/wazo_plugind/tests/test_service.py
+++ b/wazo_plugind/tests/test_service.py
@@ -1,9 +1,9 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
 from hamcrest import assert_that, calling, equal_to, has_properties
-from mock import Mock, patch, sentinel as s
+from unittest.mock import Mock, patch, sentinel as s
 from wazo_test_helpers.hamcrest.raises import raises
 
 from ..db import MarketDB, Plugin


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package