### PR TITLE
Increase test timeout to 10 seconds

### DIFF
--- a/integration_tests/suite/test_plugin_installation.py
+++ b/integration_tests/suite/test_plugin_installation.py
@@ -234,7 +234,7 @@ class TestPluginInstallation(BaseIntegrationTest):
                 ),
             )
 
-        until.assert_(assert_received, events, tries=5)
+        until.assert_(assert_received, events, tries=10)
 
         build_success_exists = self.exists_in_container('/tmp/results/build_success')
         package_success_exists = self.exists_in_container(


### PR DESCRIPTION
Why:

* Because of recent changes, either bus changes or system degradation (further investigation is needed to determine exact cause), the test `test_when_it_works` timeout is adjusted to 10 seconds.

Previously, the test was waiting 5 seconds for the `completed` event to be received, but it now seems to take about ~8 seconds to successfully complete