### PR TITLE
plugin installation can be slow on slow host

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -190,7 +190,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
                 ),
             )
 
-        until.assert_(assert_received, events, timeout=30)
+        until.assert_(assert_received, events, timeout=60)
         return result
 
     def uninstall_plugin(self, namespace, name, **kwargs):


### PR DESCRIPTION
why: installing wazo-dev-ssh-pubkeys will install openssh server and
will generate keys and other stuff. Moreover, depending of the mirror
speed and other dependencies, the installation time may varying