### PR TITLE
disable consul/service_discovery by default

### DIFF
--- a/debian/wazo-plugind.links
+++ b/debian/wazo-plugind.links
@@ -1,2 +1,0 @@
-/var/lib/consul/default_xivo_consul_config.yml /etc/wazo-plugind/conf.d/050-xivo-consul-config.yml
-/var/lib/consul/default_xivo_consul_token.yml /etc/wazo-plugind/conf.d/050-xivo-consul-token.yml

--- a/etc/wazo-plugind/config.yml
+++ b/etc/wazo-plugind/config.yml
@@ -22,38 +22,42 @@ bus:
   exchange_name: xivo
   exchange_type: topic
 
-# Consul connection settings
-consul:
-  scheme: http
-  host: localhost
-  port: 8500
-  token: 'the_one_ring'
-
-# Service discovery configuration. All time intervals are in seconds
-service_discovery:
-  # Indicates whether of not to use service discovery.
-  # It should only be disabled for testing purposes
-  enabled: true
-  # The address that will be received by other services using service discovery.
-  # Use "advertise_address: auto" to enable ip address detection based on
-  # advertise_address_interface
-  advertise_address: auto
-  # If advertise_address is "auto" this interface will be used to find the ip
-  # address to advertise. Ignored otherwise
-  advertise_address_interface: eth0
-  advertise_port: 9503
-  # The number of seconds that consul will wait between 2 ttl messages to mark
-  # this service as up
-  ttl_interval: 30
-  # The time interval before the service sends a new ttl message to consul
-  refresh_interval: 27
-  # The time interval to detect that the service is running when starting
-  retry_interval: 2
-  extra_tags: []
-
 # Authentication server connection settings
 auth:
   host: localhost
   port: 9497
   prefix: null
   https: false
+
+service_discovery:
+  enabled: false
+
+# Example of service discovery settings
+#
+# Necessary to use service discovery
+# consul:
+#   scheme: http
+#   host: localhost
+#   port: 8500
+#   token: 'the_one_ring'
+#
+# # All time intervals are in seconds
+# service_discovery:
+#   # Indicates whether of not to use service discovery.
+#   enabled: true
+#   # The address that will be received by other services using service discovery.
+#   # Use "advertise_address: auto" to enable ip address detection based on
+#   # advertise_address_interface
+#   advertise_address: auto
+#   # If advertise_address is "auto" this interface will be used to find the ip
+#   # address to advertise. Ignored otherwise
+#   advertise_address_interface: eth0
+#   advertise_port: 9503
+#   # The number of seconds that consul will wait between 2 ttl messages to mark
+#   # this service as up
+#   ttl_interval: 30
+#   # The time interval before the service sends a new ttl message to consul
+#   refresh_interval: 27
+#   # The time interval to detect that the service is running when starting
+#   retry_interval: 2
+#   extra_tags: []

--- a/etc/wazo-plugind/config.yml
+++ b/etc/wazo-plugind/config.yml
@@ -32,12 +32,12 @@ auth:
 service_discovery:
   enabled: false
 
-# Example of service discovery settings
+# Example settings to enable service discovery
 #
 # Necessary to use service discovery
 # consul:
 #   scheme: http
-#   host: localhost
+#   host: consul.example.com
 #   port: 8500
 #   token: 'the_one_ring'
 #

--- a/integration_tests/assets/etc/wazo-plugind/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-plugind/conf.d/50-default.yml
@@ -16,6 +16,3 @@ market:
   port: 8000
   https: False
   version: 0.1
-
-service_discovery:
-  enabled: false

--- a/wazo_plugind/config.py
+++ b/wazo_plugind/config.py
@@ -60,12 +60,15 @@ _DEFAULT_CONFIG = dict(
         'exchange_name': 'xivo',
         'exchange_type': 'topic',
     },
-    consul={'scheme': 'http', 'host': 'localhost', 'port': 8500},
+    consul={
+        'scheme': 'http',
+        'port': 8500,
+    },
     service_discovery={
+        'enabled': False,
         'advertise_address': 'auto',
         'advertise_address_interface': 'eth0',
         'advertise_port': _DEFAULT_HTTP_PORT,
-        'enabled': True,
         'ttl_interval': 30,
         'refresh_interval': 27,
         'retry_interval': 2,


### PR DESCRIPTION
why: consul is not used in default install
- Remove host key from default consul setting to block service start if
  not defined
- Keep common service_discovery and consul key in config.py to avoid
  to redefine everything when using these settings