### PR TITLE
use docker compose without hyphen command

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -7,7 +7,7 @@ and execute make create-git.
 
 These repositories should not be commited.
 
-To reference the created repos in your test or docker-compose use the same name and location without the "-git"
+To reference the created repos in your test or docker compose use the same name and location without the "-git"
 
 Example:
 


### PR DESCRIPTION
why: it's now the recommended way to use docker compose